### PR TITLE
URL Cleanup

### DIFF
--- a/addon-git/pom.xml
+++ b/addon-git/pom.xml
@@ -14,7 +14,7 @@
     <repositories>
         <repository>
             <id>jgit-repository</id>
-            <url>http://download.eclipse.org/jgit/maven</url>
+            <url>https://download.eclipse.org/jgit/maven</url>
         </repository>
     </repositories>
     <dependencies>

--- a/addon-op4j/pom.xml
+++ b/addon-op4j/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>org.springframework.roo.addon.op4j</artifactId>
     <packaging>bundle</packaging>
     <name>Spring Roo - Addon - Op4J</name>
-    <description>Support for the configuration and integration of OP4J (http://www.op4j.org/) functionalities through an AspectJ ITD.</description>
+    <description>Support for the configuration and integration of OP4J (https://www.op4j.org/) functionalities through an AspectJ ITD.</description>
     <dependencies>
         <!-- OSGi -->
         <dependency>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.op4j.org/ migrated to:  
  https://www.op4j.org/ ([https](https://www.op4j.org/) result 200).
* http://download.eclipse.org/jgit/maven migrated to:  
  https://download.eclipse.org/jgit/maven ([https](https://download.eclipse.org/jgit/maven) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance