### PR TITLE
URL Cleanup

### DIFF
--- a/addon-git/pom.xml
+++ b/addon-git/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>
@@ -14,7 +14,7 @@
     <repositories>
         <repository>
             <id>jgit-repository</id>
-            <url>http://download.eclipse.org/jgit/maven</url>
+            <url>https://download.eclipse.org/jgit/maven</url>
         </repository>
     </repositories>
     <dependencies>

--- a/addon-gwt/pom.xml
+++ b/addon-gwt/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/applicationContext-locators-template.xml
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/applicationContext-locators-template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-3.1.xsd">
 	<!-- Locator Beans -->   
     
 </beans>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/configuration.xml
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/configuration.xml
@@ -8,7 +8,7 @@
             <repository>
                 <id>maven.springframework.org.external</id>
                 <name>SpringSource Maven Repository - External Releases</name>
-                <url>http://maven.springframework.org/external</url>
+                <url>https://maven.springframework.org/external</url>
             </repository>
         </repositories>
         <dependencies>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/module/client/scaffold/ScaffoldDesktopShell-template.ui.xml
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/module/client/scaffold/ScaffoldDesktopShell-template.ui.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 			 xmlns:g='urn:import:com.google.gwt.user.client.ui'
 			 xmlns:s='urn:import:__TOP_LEVEL_PACKAGE__.client.scaffold.ui'>
@@ -135,10 +135,10 @@
 			<g:HTML>
 				<div class='{style.logos}'>
 					<span>Powered by:</span>
-					<a href='http://code.google.com/webtoolkit/'>
+					<a href='https://code.google.com/webtoolkit/'>
 						<div class='{style.gwtLogo}'></div>
 					</a>
-					<a href='http://www.springsource.org/roo/'>
+					<a href='https://www.springsource.org/roo/'>
 						<div class='{style.rooLogo}'></div>
 					</a>
 				</div>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/module/client/scaffold/ScaffoldMobileShell-template.ui.xml
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/module/client/scaffold/ScaffoldMobileShell-template.ui.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
 		xmlns:ui='urn:ui:com.google.gwt.uibinder'
 		xmlns:g='urn:import:com.google.gwt.user.client.ui'

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/module/client/scaffold/ui/MobileProxyListView-template.ui.xml
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/module/client/scaffold/ui/MobileProxyListView-template.ui.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
 		xmlns:ui='urn:ui:com.google.gwt.uibinder'
 		xmlns:g='urn:import:com.google.gwt.user.client.ui'

--- a/addon-jsf/pom.xml
+++ b/addon-jsf/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>

--- a/addon-jsf/src/main/assembly/assembly.xml
+++ b/addon-jsf/src/main/assembly/assembly.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 https://maven.apache.org/xsd/assembly-1.1.0.xsd">
 	<formats>
 		<format>zip</format>
 	</formats>

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/WEB-INF/faces-config-template.xml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/WEB-INF/faces-config-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <faces-config xmlns="http://java.sun.com/xml/ns/javaee" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd" 
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd" 
     version="2.0">
     <application>
         <el-resolver>org.springframework.web.jsf.el.SpringBeanFacesELResolver</el-resolver>

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/WEB-INF/web-template.xml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/WEB-INF/web-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          version="3.0"> 
     <display-name>TO_BE_CHANGED_BY_LISTENER</display-name>
     <description>TO_BE_CHANGED_BY_LISTENER</description>

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/configuration.xml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/configuration.xml
@@ -17,7 +17,7 @@
             <repositories>
                 <repository>
                     <id>java.net.m2</id>
-                    <url>http://download.java.net/maven/2</url>
+                    <url>https://download.java.net/maven/2</url>
                 </repository>
             </repositories>
         </jsf-implementation>
@@ -60,7 +60,7 @@
                 <repository>
                     <id>prime-repo</id>
                     <name>PrimeFaces Maven Repository</name>
-                    <url>http://repository.primefaces.org</url>
+                    <url>https://repository.primefaces.org</url>
                     <layout>default</layout>
                 </repository>
             </repositories>

--- a/addon-layers-repository-mongo/pom.xml
+++ b/addon-layers-repository-mongo/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>

--- a/addon-layers-repository-mongo/src/main/resources/org/springframework/roo/addon/layers/repository/mongo/applicationContext-mongo.xml
+++ b/addon-layers-repository-mongo/src/main/resources/org/springframework/roo/addon/layers/repository/mongo/applicationContext-mongo.xml
@@ -4,12 +4,12 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:mongo="http://www.springframework.org/schema/data/mongo"
        xmlns:cloud="http://schema.cloudfoundry.org/spring"
-       xsi:schemaLocation="http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd
        http://www.springframework.org/schema/data/mongo
-       http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd
+       https://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd
        http://www.springframework.org/schema/beans
-       http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-       http://schema.cloudfoundry.org/spring http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd">
+       https://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+       http://schema.cloudfoundry.org/spring https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd">
 
     <mongo:db-factory id="mongoDbFactory" host="${mongo.host}" port="${mongo.port}"/>
 

--- a/addon-layers-repository-mongo/src/main/resources/org/springframework/roo/addon/layers/repository/mongo/configuration.xml
+++ b/addon-layers-repository-mongo/src/main/resources/org/springframework/roo/addon/layers/repository/mongo/configuration.xml
@@ -5,7 +5,7 @@
             <repository>
                 <id>spring-maven-snapshot</id>
                 <name>Spring Maven MILESTONE Repository</name>
-                <url>http://maven.springframework.org/milestone</url>
+                <url>https://maven.springframework.org/milestone</url>
             </repository>
         </repositories>
         <dependencies>

--- a/addon-op4j/pom.xml
+++ b/addon-op4j/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>
@@ -10,7 +10,7 @@
     <artifactId>org.springframework.roo.addon.op4j</artifactId>
     <packaging>bundle</packaging>
     <name>Spring Roo - Addon - Op4J</name>
-    <description>Support for the configuration and integration of OP4J (http://www.op4j.org/) functionalities through an AspectJ ITD.</description>
+    <description>Support for the configuration and integration of OP4J (https://www.op4j.org/) functionalities through an AspectJ ITD.</description>
     <dependencies>
         <!-- OSGi -->
         <dependency>

--- a/addon-solr/pom.xml
+++ b/addon-solr/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.roo</groupId>

--- a/addon-solr/src/main/resources/org/springframework/roo/addon/solr/schema-template.xml
+++ b/addon-solr/src/main/resources/org/springframework/roo/addon/solr/schema-template.xml
@@ -34,7 +34,7 @@
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         https://www.w3.org/TR/xmlschema-2/#dateTime    
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://download.java.net/maven/2 (301) with 1 occurrences migrated to:  
  https://download.java.net/maven/2 ([https](https://download.java.net/maven/2) result 404).
* http://maven.springframework.org/external (404) with 1 occurrences migrated to:  
  https://maven.springframework.org/external ([https](https://maven.springframework.org/external) result 404).
* http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd (404) with 1 occurrences migrated to:  
  https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd ([https](https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.8.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dl.google.com/gwt/DTD/xhtml.ent with 3 occurrences migrated to:  
  https://dl.google.com/gwt/DTD/xhtml.ent ([https](https://dl.google.com/gwt/DTD/xhtml.ent) result 200).
* http://maven.apache.org/xsd/assembly-1.1.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.0.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.0.xsd) result 200).
* http://repository.primefaces.org with 1 occurrences migrated to:  
  https://repository.primefaces.org ([https](https://repository.primefaces.org) result 200).
* http://www.op4j.org/ with 1 occurrences migrated to:  
  https://www.op4j.org/ ([https](https://www.op4j.org/) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* http://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd ([https](https://www.springframework.org/schema/data/mongo/spring-mongo-1.0.xsd) result 200).
* http://www.springframework.org/schema/security/spring-security-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-3.1.xsd ([https](https://www.springframework.org/schema/security/spring-security-3.1.xsd) result 200).
* http://www.w3.org/TR/xmlschema-2/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/xmlschema-2/ ([https](https://www.w3.org/TR/xmlschema-2/) result 200).
* http://code.google.com/webtoolkit/ with 1 occurrences migrated to:  
  https://code.google.com/webtoolkit/ ([https](https://code.google.com/webtoolkit/) result 301).
* http://download.eclipse.org/jgit/maven with 1 occurrences migrated to:  
  https://download.eclipse.org/jgit/maven ([https](https://download.eclipse.org/jgit/maven) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd) result 302).
* http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd) result 302).
* http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://www.springsource.org/roo/ with 1 occurrences migrated to:  
  https://www.springsource.org/roo/ ([https](https://www.springsource.org/roo/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/javaee with 4 occurrences
* http://maven.apache.org/POM/4.0.0 with 12 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 with 2 occurrences
* http://schema.cloudfoundry.org/spring with 2 occurrences
* http://www.springframework.org/schema/beans with 4 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/data/mongo with 2 occurrences
* http://www.springframework.org/schema/security with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 11 occurrences