### PR TITLE
URL Cleanup

### DIFF
--- a/addon-git/legal-git.txt
+++ b/addon-git/legal-git.txt
@@ -7,9 +7,9 @@ All code in this project is original work, except as disclosed below.
 -----------------------------------------------------------------------
 
 Licensed Software: JGit
-Software Web Site: http://www.eclipse.org/jgit/
+Software Web Site: https://www.eclipse.org/jgit/
 Effective License: Eclipse Distribution License - v 1.0
-License Info Page: http://www.eclipse.org/org/documents/edl-v10.php
+License Info Page: https://www.eclipse.org/org/documents/edl-v10.php
 
 JGit is used to integrate git functionality into Spring Roo.
 

--- a/addon-gwt/legal-addon-gwt.txt
+++ b/addon-gwt/legal-addon-gwt.txt
@@ -7,7 +7,7 @@ All code in this project is original work, except as disclosed below.
 -----------------------------------------------------------------------
 
 Licensed Software: Apache Velocity
-Software Web Site: http://velocity.apache.org/
+Software Web Site: https://velocity.apache.org/
 Effective License: Apache License V2.0
 License Info Page: http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -17,7 +17,7 @@ provides template services for writing files by the add-on.
 -----------------------------------------------------------------------
 
 Licensed Software: Apache Commons Collections
-Software Web Site: http://commons.apache.org/collections/
+Software Web Site: https://commons.apache.org/collections/
 Effective License: Apache License V2.0
 License Info Page: http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -27,7 +27,7 @@ is required by Apache Velocity.
 -----------------------------------------------------------------------
 
 Licensed Software: Apache Commons Logging
-Software Web Site: http://commons.apache.org/logging/
+Software Web Site: https://commons.apache.org/logging/
 Effective License: Apache License V2.0
 License Info Page: http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/addon-gwt/src/main/java/org/springframework/roo/addon/gwt/GwtTemplateServiceImpl.java
+++ b/addon-gwt/src/main/java/org/springframework/roo/addon/gwt/GwtTemplateServiceImpl.java
@@ -115,7 +115,7 @@ public class GwtTemplateServiceImpl implements GwtTemplateService {
                 public InputSource resolveEntity(final String publicId,
                         final String systemId) throws SAXException, IOException {
                     if (systemId
-                            .equals("http://dl.google.com/gwt/DTD/xhtml.ent")) {
+                            .equals("https://dl.google.com/gwt/DTD/xhtml.ent")) {
                         return new InputSource(FileUtils.getInputStream(
                                 GwtScaffoldMetadata.class,
                                 "templates/xhtml.ent"));

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/CollectionEditorUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/CollectionEditorUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 			 xmlns:g='urn:import:com.google.gwt.user.client.ui'>
 	<ui:style type="{{=packageName}}.{{=boundCollectionType}}{{=collectionType}}Editor.Style">

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopDetailsViewUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopDetailsViewUiXml.xtm
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
   xmlns:g='urn:import:com.google.gwt.user.client.ui'>
  <ui:style>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopEditViewUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopEditViewUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
   xmlns:g='urn:import:com.google.gwt.user.client.ui'
   xmlns:d='urn:import:com.google.gwt.user.datepicker.client'

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopListViewUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopListViewUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
   xmlns:g='urn:import:com.google.gwt.user.client.ui'
   xmlns:b='urn:import:com.google.gwt.user.cellview.client'>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/ListEditorUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/ListEditorUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:g='urn:import:com.google.gwt.user.client.ui'>
     <ui:style type="{{=packageName}}.{{=className}}.Style">

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/MobileDetailsViewUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/MobileDetailsViewUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
   xmlns:g='urn:import:com.google.gwt.user.client.ui'>
  <ui:style>

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/MobileEditViewUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/MobileEditViewUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
   xmlns:g='urn:import:com.google.gwt.user.client.ui'
   xmlns:d='urn:import:com.google.gwt.user.datepicker.client'

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/SimpleCollectionEditorUiXml.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/SimpleCollectionEditorUiXml.xtm
@@ -1,4 +1,4 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<!DOCTYPE ui:UiBinder SYSTEM "https://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 			 xmlns:g='urn:import:com.google.gwt.user.client.ui'>
 	<ui:style type="{{=packageName}}.{{=boundCollectionType}}{{=collectionType}}Editor.Style">

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/xhtml.ent
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/xhtml.ent
@@ -11,16 +11,16 @@
   of the Google Web Toolkit, it should be useful for any XML
   document. It's essentially a union of:
 
-    http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent
-    http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent
-    http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent
+    https://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent
+    https://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent
+    https://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent
 
   Sample usage:
   <!DOCTYPE ui:UiBinder
     SYSTEM "https://dl-ssl.google.com/download/gwt/DTD/xhtml.ent">
 
   This file is maintained at
-  <http://google-web-toolkit.googlecode.com/svn/trunk/user/src/com/google/gwt/uibinder/resources/xhtml.ent>. Changes
+  <https://google-web-toolkit.googlecode.com/svn/trunk/user/src/com/google/gwt/uibinder/resources/xhtml.ent>. Changes
   made to it must be propagated to the URL in the sample above.
 -->
 

--- a/addon-jsf/src/main/java/org/springframework/roo/addon/jsf/Theme.java
+++ b/addon-jsf/src/main/java/org/springframework/roo/addon/jsf/Theme.java
@@ -2,7 +2,7 @@ package org.springframework.roo.addon.jsf;
 
 /**
  * Enum to represent PrimeFaces themes. PrimeFaces is integrated with the <a
- * href="http://jqueryui.com/themeroller/">ThemeRoller</a> CSS framework.
+ * href="https://jqueryui.com/themeroller/">ThemeRoller</a> CSS framework.
  * 
  * @author Alan Stewart
  * @since 1.2.0

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/pages/content-template.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/pages/content-template.xhtml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:c="http://java.sun.com/jstl/core"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <ui:composition template="../templates/layout.xhtml">
   <ui:define name="content">
     <h:form prependId="false" id="growlForm">

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/pages/main.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/pages/main.xhtml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <ui:composition template="../templates/layout.xhtml">
   <ui:define name="content">
     <p:panel id="mainPanel" toggleable="true" toggleSpeed="250">

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/content.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/content.xhtml
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <ui:composition>
   <ui:insert name="content" />
 </ui:composition>

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/footer.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/footer.xhtml
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <ui:composition>
   <div id="footer">
     <h:form>
@@ -60,7 +60,7 @@
           </h:panelGrid>
         </h:panelGrid>
         <h:panelGrid align="right">
-          <h:outputLink value="http://springsource.org">
+          <h:outputLink value="https://springsource.org">
             <h:graphicImage library="images" name="springsource-logo.png" alt="SpringSource" />
           </h:outputLink>
         </h:panelGrid>

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/header.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/header.xhtml
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <ui:composition>
   <title>#{applicationBean.appName}</title>
   <h:outputStylesheet library="css" name="standard.css" />

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/layout.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/layout.xhtml
@@ -1,10 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:c="http://java.sun.com/jstl/core"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <f:view locale="#{localeBean.locale}" contentType="text/html">
   <h:head>
     <ui:insert name="header">

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/menu.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/templates/menu.xhtml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <ui:composition>
   <p:menu model="#{applicationBean.menuModel}" style="width:198px" />
 </ui:composition>

--- a/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/viewExpired.xhtml
+++ b/addon-jsf/src/main/resources/org/springframework/roo/addon/jsf/viewExpired.xhtml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:f="https://java.sun.com/jsf/core"
       xmlns:h="http://java.sun.com/jsf/html"
       xmlns:ui="http://java.sun.com/jsf/facelets"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="https://primefaces.org/ui">
 <f:view locale="#{localeBean.locale}" contentType="text/html">
   <h:head>
     <title>#{applicationBean.appName}</title>

--- a/addon-solr/src/main/java/org/springframework/roo/addon/solr/SolrOperationsImpl.java
+++ b/addon-solr/src/main/java/org/springframework/roo/addon/solr/SolrOperationsImpl.java
@@ -117,7 +117,7 @@ public class SolrOperationsImpl implements SolrOperations {
                 root.setAttribute(
                         "xsi:schemaLocation",
                         root.getAttribute("xsi:schemaLocation")
-                                + "  http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd");
+                                + "  http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task-3.0.xsd");
             }
             root.appendChild(new XmlElementBuilder("task:annotation-driven",
                     appCtx).addAttribute("executor", "asyncExecutor")


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.jcraft.com/jsch/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.jcraft.com/jsch/) result AnnotatedConnectException).
* [ ] http://www.jcraft.com/jsch/LICENSE.txt (200) with 1 occurrences could not be migrated:  
   ([https](https://www.jcraft.com/jsch/LICENSE.txt) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent) result ReadTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 6 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* [ ] http://google-web-toolkit.googlecode.com/svn/trunk/user/src/com/google/gwt/uibinder/resources/xhtml.ent (404) with 1 occurrences migrated to:  
  https://google-web-toolkit.googlecode.com/svn/trunk/user/src/com/google/gwt/uibinder/resources/xhtml.ent ([https](https://google-web-toolkit.googlecode.com/svn/trunk/user/src/com/google/gwt/uibinder/resources/xhtml.ent) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dl.google.com/gwt/DTD/xhtml.ent with 9 occurrences migrated to:  
  https://dl.google.com/gwt/DTD/xhtml.ent ([https](https://dl.google.com/gwt/DTD/xhtml.ent) result 200).
* [ ] http://jqueryui.com/themeroller/ with 1 occurrences migrated to:  
  https://jqueryui.com/themeroller/ ([https](https://jqueryui.com/themeroller/) result 200).
* [ ] http://velocity.apache.org/ with 1 occurrences migrated to:  
  https://velocity.apache.org/ ([https](https://velocity.apache.org/) result 200).
* [ ] http://www.eclipse.org/jgit/ with 1 occurrences migrated to:  
  https://www.eclipse.org/jgit/ ([https](https://www.eclipse.org/jgit/) result 200).
* [ ] http://www.eclipse.org/org/documents/edl-v10.php with 1 occurrences migrated to:  
  https://www.eclipse.org/org/documents/edl-v10.php ([https](https://www.eclipse.org/org/documents/edl-v10.php) result 200).
* [ ] http://www.springframework.org/schema/task/spring-task-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task-3.0.xsd ([https](https://www.springframework.org/schema/task/spring-task-3.0.xsd) result 200).
* [ ] http://primefaces.org/ui with 8 occurrences migrated to:  
  https://primefaces.org/ui ([https](https://primefaces.org/ui) result 301).
* [ ] http://springsource.org with 1 occurrences migrated to:  
  https://springsource.org ([https](https://springsource.org) result 301).
* [ ] http://commons.apache.org/collections/ with 1 occurrences migrated to:  
  https://commons.apache.org/collections/ ([https](https://commons.apache.org/collections/) result 302).
* [ ] http://commons.apache.org/logging/ with 1 occurrences migrated to:  
  https://commons.apache.org/logging/ ([https](https://commons.apache.org/logging/) result 302).
* [ ] http://java.sun.com/jsf/core with 8 occurrences migrated to:  
  https://java.sun.com/jsf/core ([https](https://java.sun.com/jsf/core) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/JSP/Page with 4 occurrences
* http://java.sun.com/jsf/facelets with 8 occurrences
* http://java.sun.com/jsf/html with 8 occurrences
* http://java.sun.com/jsp/jstl/core with 3 occurrences
* http://java.sun.com/jsp/jstl/functions with 3 occurrences
* http://java.sun.com/jstl/core with 2 occurrences
* http://localhost:8983/solr with 2 occurrences
* http://www.springframework.org/schema/task with 2 occurrences
* http://www.springframework.org/tags with 3 occurrences
* http://www.springframework.org/tags/form with 3 occurrences
* http://www.w3.org/1999/xhtml with 8 occurrences