### PR TITLE
URL Cleanup

### DIFF
--- a/addon-gwt/legal-addon-gwt.txt
+++ b/addon-gwt/legal-addon-gwt.txt
@@ -9,7 +9,7 @@ All code in this project is original work, except as disclosed below.
 Licensed Software: Apache Velocity
 Software Web Site: http://velocity.apache.org/
 Effective License: Apache License V2.0
-License Info Page: http://www.apache.org/licenses/LICENSE-2.0.txt
+License Info Page: https://www.apache.org/licenses/LICENSE-2.0.txt
 
 Apache Velocity is a runtime dependency of this module. Velocity
 provides template services for writing files by the add-on.
@@ -19,7 +19,7 @@ provides template services for writing files by the add-on.
 Licensed Software: Apache Commons Collections
 Software Web Site: http://commons.apache.org/collections/
 Effective License: Apache License V2.0
-License Info Page: http://www.apache.org/licenses/LICENSE-2.0.txt
+License Info Page: https://www.apache.org/licenses/LICENSE-2.0.txt
 
 Apache Commons Collections is a runtime dependency of this module. It
 is required by Apache Velocity.
@@ -29,7 +29,7 @@ is required by Apache Velocity.
 Licensed Software: Apache Commons Logging
 Software Web Site: http://commons.apache.org/logging/
 Effective License: Apache License V2.0
-License Info Page: http://www.apache.org/licenses/LICENSE-2.0.txt
+License Info Page: https://www.apache.org/licenses/LICENSE-2.0.txt
 
 Apache Commons Logging is a runtime dependency of this module. It is
 required by Apache Velocity.

--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/gwt-module.dtd
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/gwt-module.dtd
@@ -5,7 +5,7 @@
 <!-- may not use this file except in compliance with the License. You may   -->
 <!-- may obtain a copy of the License at                                    -->
 <!--                                                                        -->
-<!-- http://www.apache.org/licenses/LICENSE-2.0                             -->
+<!-- https://www.apache.org/licenses/LICENSE-2.0                             -->
 <!--                                                                        -->
 <!-- Unless required by applicable law or agreed to in writing, software    -->
 <!-- distributed under the License is distributed on an "AS IS" BASIS,      -->

--- a/addon-solr/src/main/resources/org/springframework/roo/addon/solr/schema-template.xml
+++ b/addon-solr/src/main/resources/org/springframework/roo/addon/solr/schema-template.xml
@@ -7,7 +7,7 @@
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.txt with 3 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).